### PR TITLE
Improve .gitmodules parsing in GitLab provider

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1,6 +1,7 @@
 import difflib
 import hashlib
 import re
+import configparser
 from typing import Optional, Tuple, Any, Union
 from urllib.parse import urlparse, parse_qs
 import urllib.parse
@@ -123,15 +124,22 @@ class GitLabProvider(GitProvider):
             return {}
 
         out: dict[str, str] = {}
-        cur_path: str | None = None
-        for line in content.splitlines():
-            s = line.strip()  # ensure 's' is str
-            if s.startswith("[submodule"):
-                cur_path = None
-            elif s.startswith("path ="):
-                cur_path = s.split("=", 1)[1].strip()
-            elif s.startswith("url =") and cur_path:
-                out[cur_path] = s.split("=", 1)[1].strip()
+
+        parser = configparser.RawConfigParser(inline_comment_prefixes=("#", ";"))
+        try:
+            parser.read_string(content)
+        except Exception:
+            return out
+
+        for section in parser.sections():
+            if not section.lower().startswith("submodule"):
+                continue
+            path = parser.get(section, "path", fallback=None)
+            url = parser.get(section, "url", fallback=None)
+            if path and url:
+                path = path.strip().strip('"').strip("'")
+                url = url.strip().strip('"').strip("'")
+                out[path] = url
         return out
 
     def _url_to_project_path(self, url: str) -> str | None:

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -141,7 +141,65 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = content
         mock_project.files.get.return_value = mock_file
-        
+
         result = gitlab_provider.get_pr_file_content("test.md", "main")
-        
-        assert result == expected 
+
+        assert result == expected
+
+    def test_get_gitmodules_map_quoted_paths(self, gitlab_provider, mock_project):
+        gitlab_provider.mr = type('MR', (), {'target_branch': 'main', 'source_branch': 'feature'})()
+        mock_file = MagicMock(ProjectFile)
+        mock_file.decode.return_value = (
+            """
+[submodule "mod1"]
+    path = "libs/foo"
+    url = "git@example.com:foo.git"
+"""
+        )
+        mock_project.files.get.return_value = mock_file
+
+        result = gitlab_provider._get_gitmodules_map()
+
+        assert result == {"libs/foo": "git@example.com:foo.git"}
+
+    def test_get_gitmodules_map_multiple_submodules(self, gitlab_provider, mock_project):
+        gitlab_provider.mr = type('MR', (), {'target_branch': 'main', 'source_branch': 'feature'})()
+        mock_file = MagicMock(ProjectFile)
+        mock_file.decode.return_value = (
+            """
+[submodule "mod1"]
+    path = libs/foo
+    url = https://example.com/foo.git
+[submodule "mod2"]
+    path = libs/bar
+    url = https://example.com/bar.git
+"""
+        )
+        mock_project.files.get.return_value = mock_file
+
+        result = gitlab_provider._get_gitmodules_map()
+
+        assert result == {
+            "libs/foo": "https://example.com/foo.git",
+            "libs/bar": "https://example.com/bar.git",
+        }
+
+    def test_get_gitmodules_map_commented_lines(self, gitlab_provider, mock_project):
+        gitlab_provider.mr = type('MR', (), {'target_branch': 'main', 'source_branch': 'feature'})()
+        mock_file = MagicMock(ProjectFile)
+        mock_file.decode.return_value = (
+            """
+# Initial comment
+[submodule "mod1"]
+    path = libs/foo # inline comment
+    url = https://example.com/foo.git # trailing comment
+# [submodule "ignored"]
+#    path = libs/ignored
+#    url = https://example.com/ignored.git
+"""
+        )
+        mock_project.files.get.return_value = mock_file
+
+        result = gitlab_provider._get_gitmodules_map()
+
+        assert result == {"libs/foo": "https://example.com/foo.git"}


### PR DESCRIPTION
## Summary
- parse `.gitmodules` using `configparser` to support comments and quoted values
- add tests for quoted paths, multiple submodules, and commented lines

## Testing
- `PYTHONPATH=. pytest tests/unittest/test_gitlab_provider.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae17f4fb4c8330bc112db9287d110f