### PR TITLE
Avoid broad GitLab project search

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1,13 +1,14 @@
 import difflib
 import hashlib
 import re
-from typing import Optional, Tuple, Any, Union
-from urllib.parse import urlparse, parse_qs
 import urllib.parse
+from typing import Any, Optional, Tuple, Union
+from urllib.parse import parse_qs, urlparse
 
 import gitlab
 import requests
-from gitlab import GitlabGetError, GitlabAuthenticationError, GitlabCreateError, GitlabUpdateError
+from gitlab import (GitlabAuthenticationError, GitlabCreateError,
+                    GitlabGetError, GitlabUpdateError)
 
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
@@ -39,12 +40,12 @@ class GitLabProvider(GitProvider):
             raise ValueError("GitLab personal access token is not set in the config file")
         # Authentication method selection via configuration
         auth_method = get_settings().get("GITLAB.AUTH_TYPE", "oauth_token")
-        
+
         # Basic validation of authentication type
         if auth_method not in ["oauth_token", "private_token"]:
             raise ValueError(f"Unsupported GITLAB.AUTH_TYPE: '{auth_method}'. "
                            f"Must be 'oauth_token' or 'private_token'.")
-        
+
         # Create GitLab instance based on authentication method
         try:
             if auth_method == "oauth_token":
@@ -151,11 +152,9 @@ class GitLabProvider(GitProvider):
 
     def _project_by_path(self, proj_path: str):
         """
-        Resolve a project by path with multiple strategies:
-        1) URL-encoded path_with_namespace
-        2) Raw path_with_namespace
-        3) Search fallback + exact match on path_with_namespace (case-insensitive)
-        Returns a project object or None.
+        Resolve a project by its ``path_with_namespace`` using exact lookup only.
+        The method attempts both URL-encoded and raw forms. If the project cannot
+        be resolved, a warning is logged and ``None`` is returned.
         """
         if not proj_path:
             return None
@@ -173,22 +172,7 @@ class GitLabProvider(GitProvider):
         except Exception:
             pass
 
-        # 3) Search fallback
-        try:
-            name = proj_path.split("/")[-1]
-            # membership=True so we don't leak other people's repos
-            matches = self.gl.projects.list(search=name, simple=True, membership=True, per_page=100)
-            # prefer exact path_with_namespace match (case-insensitive)
-            for p in matches:
-                pwn = getattr(p, "path_with_namespace", "")
-                if pwn.lower() == proj_path.lower():
-                    return self.gl.projects.get(p.id)
-            # as a last resort, first match of that name
-            if matches:
-                return self.gl.projects.get(matches[0].id)
-        except Exception:
-            pass
-
+        get_logger().warning(f"[submodule] project not found for {proj_path}; skipping expansion")
         return None
 
     def _compare_submodule(self, proj_path: str, old_sha: str, new_sha: str) -> list[dict]:
@@ -341,11 +325,11 @@ class GitLabProvider(GitProvider):
         """Create or update a file in the GitLab repository."""
         try:
             project = self.gl.projects.get(self.id_project)
-            
+
             if not message:
                 action = "Update" if contents else "Create"
                 message = f"{action} {file_path}"
-            
+
             try:
                 existing_file = project.files.get(file_path, branch)
                 existing_file.content = contents
@@ -784,14 +768,14 @@ class GitLabProvider(GitProvider):
             if not self.id_mr:
                 get_logger().warning("Cannot add eyes reaction: merge request ID is not set.")
                 return None
-            
+
             mr = self.gl.projects.get(self.id_project).mergerequests.get(self.id_mr)
             comment = mr.notes.get(issue_comment_id)
-            
+
             if not comment:
                 get_logger().warning(f"Comment with ID {issue_comment_id} not found in merge request {self.id_mr}.")
                 return None
-            
+
             award_emoji = comment.awardemojis.create({
                 'name': 'eyes'
             })
@@ -805,20 +789,20 @@ class GitLabProvider(GitProvider):
             if not self.id_mr:
                 get_logger().warning("Cannot remove reaction: merge request ID is not set.")
                 return False
-            
+
             mr = self.gl.projects.get(self.id_project).mergerequests.get(self.id_mr)
             comment = mr.notes.get(issue_comment_id)
 
             if not comment:
                 get_logger().warning(f"Comment with ID {issue_comment_id} not found in merge request {self.id_mr}.")
                 return False
-            
+
             reactions = comment.awardemojis.list()
             for reaction in reactions:
                 if reaction.name == reaction_id:
                     reaction.delete()
                     return True
-            
+
             get_logger().warning(f"Reaction '{reaction_id}' not found in comment {issue_comment_id}.")
             return False
         except Exception as e:

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -1,35 +1,36 @@
-import pytest
 from unittest.mock import MagicMock, patch
 
-from pr_agent.git_providers.gitlab_provider import GitLabProvider
+import pytest
 from gitlab import Gitlab
-from gitlab.v4.objects import Project, ProjectFile
 from gitlab.exceptions import GitlabGetError
+from gitlab.v4.objects import Project, ProjectFile
+
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
 
 
 class TestGitLabProvider:
     """Test suite for GitLab provider functionality."""
-    
+
     @pytest.fixture
     def mock_gitlab_client(self):
         client = MagicMock()
         return client
-    
+
     @pytest.fixture
     def mock_project(self):
         project = MagicMock()
         return project
-    
+
     @pytest.fixture
     def gitlab_provider(self, mock_gitlab_client, mock_project):
         with patch('pr_agent.git_providers.gitlab_provider.gitlab.Gitlab', return_value=mock_gitlab_client), \
              patch('pr_agent.git_providers.gitlab_provider.get_settings') as mock_settings:
-            
+
             mock_settings.return_value.get.side_effect = lambda key, default=None: {
                 "GITLAB.URL": "https://gitlab.com",
                 "GITLAB.PERSONAL_ACCESS_TOKEN": "fake_token"
             }.get(key, default)
-            
+
             mock_gitlab_client.projects.get.return_value = mock_project
             provider = GitLabProvider("https://gitlab.com/test/repo/-/merge_requests/1")
             provider.gl = mock_gitlab_client
@@ -40,9 +41,9 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = "# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.return_value = mock_file
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == "# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "main")
         mock_file.decode.assert_called_once()
@@ -51,39 +52,39 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = b"# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.return_value = mock_file
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == "# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "main")
 
     def test_get_pr_file_content_file_not_found(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = GitlabGetError("404 Not Found")
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == ""
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "main")
 
     def test_get_pr_file_content_other_exception(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = Exception("Network error")
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == ""
 
     def test_create_or_update_pr_file_create_new(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = GitlabGetError("404 Not Found")
         mock_file = MagicMock()
         mock_project.files.create.return_value = mock_file
-        
+
         new_content = "# Changelog\n\n## v1.1.0\n- New feature"
         commit_message = "Add CHANGELOG.md"
-        
+
         gitlab_provider.create_or_update_pr_file(
             "CHANGELOG.md", "feature-branch", new_content, commit_message
         )
-        
+
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "feature-branch")
         mock_project.files.create.assert_called_once_with({
             'file_path': 'CHANGELOG.md',
@@ -96,21 +97,21 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = "# Old changelog content"
         mock_project.files.get.return_value = mock_file
-        
+
         new_content = "# New changelog content"
         commit_message = "Update CHANGELOG.md"
-        
+
         gitlab_provider.create_or_update_pr_file(
             "CHANGELOG.md", "feature-branch", new_content, commit_message
         )
-        
+
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "feature-branch")
         mock_file.content = new_content
         mock_file.save.assert_called_once_with(branch="feature-branch", commit_message=commit_message)
 
     def test_create_or_update_pr_file_update_exception(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = Exception("Network error")
-        
+
         with pytest.raises(Exception):
             gitlab_provider.create_or_update_pr_file(
                 "CHANGELOG.md", "feature-branch", "content", "message"
@@ -122,10 +123,10 @@ class TestGitLabProvider:
 
     def test_method_signature_compatibility(self, gitlab_provider):
         import inspect
-        
+
         sig = inspect.signature(gitlab_provider.create_or_update_pr_file)
         params = list(sig.parameters.keys())
-        
+
         expected_params = ['file_path', 'branch', 'contents', 'message']
         assert params == expected_params
 
@@ -141,7 +142,29 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = content
         mock_project.files.get.return_value = mock_file
-        
+
         result = gitlab_provider.get_pr_file_content("test.md", "main")
-        
-        assert result == expected 
+
+        assert result == expected
+
+    def test_project_by_path_exact_match_only(self, gitlab_provider, mock_project):
+        import urllib.parse
+
+        mock_project.path_with_namespace = "groupA/RepoX"
+
+        def fake_get(path):
+            if path in (urllib.parse.quote_plus("groupA/RepoX"), "groupA/RepoX"):
+                return mock_project
+            raise GitlabGetError("404")
+
+        gitlab_provider.gl.projects.get.side_effect = fake_get
+        gitlab_provider.gl.projects.list = MagicMock(side_effect=AssertionError("search should not be used"))
+
+        assert gitlab_provider._project_by_path("groupA/RepoX") is mock_project
+
+        with patch('pr_agent.git_providers.gitlab_provider.get_logger') as mock_get_logger:
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            result = gitlab_provider._project_by_path("groupB/RepoX")
+            assert result is None
+            mock_logger.warning.assert_called_once()


### PR DESCRIPTION
## Summary
- restrict `_project_by_path` to exact path lookups and warn when project not found
- add regression test ensuring mismatched names don't match other projects

## Testing
- `pre-commit run --files pr_agent/git_providers/gitlab_provider.py tests/unittest/test_gitlab_provider.py`
- `PYTHONPATH=. pytest tests/unittest/test_gitlab_provider.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae17fc88d08330b88ac648e99767ea