### PR TITLE
Validate GitLab submodule URLs and resolve relative paths

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1,13 +1,14 @@
 import difflib
 import hashlib
 import re
-from typing import Optional, Tuple, Any, Union
-from urllib.parse import urlparse, parse_qs
 import urllib.parse
+from typing import Any, Optional, Tuple, Union
+from urllib.parse import parse_qs, urlparse
 
 import gitlab
 import requests
-from gitlab import GitlabGetError, GitlabAuthenticationError, GitlabCreateError, GitlabUpdateError
+from gitlab import (GitlabAuthenticationError, GitlabCreateError,
+                    GitlabGetError, GitlabUpdateError)
 
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
@@ -39,12 +40,12 @@ class GitLabProvider(GitProvider):
             raise ValueError("GitLab personal access token is not set in the config file")
         # Authentication method selection via configuration
         auth_method = get_settings().get("GITLAB.AUTH_TYPE", "oauth_token")
-        
+
         # Basic validation of authentication type
         if auth_method not in ["oauth_token", "private_token"]:
             raise ValueError(f"Unsupported GITLAB.AUTH_TYPE: '{auth_method}'. "
                            f"Must be 'oauth_token' or 'private_token'.")
-        
+
         # Create GitLab instance based on authentication method
         try:
             if auth_method == "oauth_token":
@@ -134,18 +135,59 @@ class GitLabProvider(GitProvider):
                 out[cur_path] = s.split("=", 1)[1].strip()
         return out
 
+    def _get_superproject_path(self) -> str | None:
+        """Return path_with_namespace of the current project (cached)."""
+        if getattr(self, "_superproject_path", None):
+            return self._superproject_path
+        try:
+            proj = self.gl.projects.get(self.id_project)
+            self._superproject_path = getattr(proj, "path_with_namespace", None)
+            return self._superproject_path
+        except Exception:
+            return None
+
     def _url_to_project_path(self, url: str) -> str | None:
         """
-        Convert ssh/https GitLab URL to 'group/subgroup/repo' project path.
+        Convert ssh/https/relative GitLab URL to 'group/subgroup/repo' project path.
+        Validates that the URL host matches the provider host and resolves '../'
+        style relative URLs using the superproject namespace.
         """
         try:
+            base_host = urllib.parse.urlparse(self.gl.url).netloc.lower().rstrip("/")
+
             if url.startswith("git@") and ":" in url:
-                path = url.split(":", 1)[1]
-            else:
-                path = urllib.parse.urlparse(url).path.lstrip("/")
+                host_part, path = url.split(":", 1)
+                host = host_part.split("@", 1)[1].lower().rstrip("/")
+                if host != base_host:
+                    raise ValueError(f"url host '{host}' does not match '{base_host}'")
+                if path.endswith(".git"):
+                    path = path[:-4]
+                return path or None
+
+            parsed = urllib.parse.urlparse(url)
+            if parsed.scheme or parsed.netloc:
+                host = parsed.netloc.lower().rstrip("/")
+                if host and host != base_host:
+                    raise ValueError(f"url host '{host}' does not match '{base_host}'")
+                path = parsed.path.lstrip("/")
+                if path.endswith(".git"):
+                    path = path[:-4]
+                return path or None
+
+            base_path = self._get_superproject_path()
+            if not base_path:
+                return None
+            base_url = f"{self.gl.url.rstrip('/')}/{base_path}/"
+            resolved = urllib.parse.urlparse(urllib.parse.urljoin(base_url, url))
+            host = resolved.netloc.lower().rstrip("/")
+            if host and host != base_host:
+                raise ValueError(f"url host '{host}' does not match '{base_host}'")
+            path = resolved.path.lstrip("/")
             if path.endswith(".git"):
                 path = path[:-4]
             return path or None
+        except ValueError:
+            raise
         except Exception:
             return None
 
@@ -242,7 +284,11 @@ class GitLabProvider(GitProvider):
                 get_logger().warning(f"[submodule] no url for '{sub_path}' in .gitmodules (skip)")
                 continue
 
-            proj_path = self._url_to_project_path(repo_url)
+            try:
+                proj_path = self._url_to_project_path(repo_url)
+            except ValueError:
+                get_logger().warning(f"[submodule] url '{repo_url}' does not match host {self.gl.url} (skip)")
+                continue
             if not proj_path:
                 get_logger().warning(f"[submodule] cannot parse project path from url '{repo_url}' (skip)")
                 continue
@@ -341,11 +387,11 @@ class GitLabProvider(GitProvider):
         """Create or update a file in the GitLab repository."""
         try:
             project = self.gl.projects.get(self.id_project)
-            
+
             if not message:
                 action = "Update" if contents else "Create"
                 message = f"{action} {file_path}"
-            
+
             try:
                 existing_file = project.files.get(file_path, branch)
                 existing_file.content = contents
@@ -784,14 +830,14 @@ class GitLabProvider(GitProvider):
             if not self.id_mr:
                 get_logger().warning("Cannot add eyes reaction: merge request ID is not set.")
                 return None
-            
+
             mr = self.gl.projects.get(self.id_project).mergerequests.get(self.id_mr)
             comment = mr.notes.get(issue_comment_id)
-            
+
             if not comment:
                 get_logger().warning(f"Comment with ID {issue_comment_id} not found in merge request {self.id_mr}.")
                 return None
-            
+
             award_emoji = comment.awardemojis.create({
                 'name': 'eyes'
             })
@@ -805,20 +851,20 @@ class GitLabProvider(GitProvider):
             if not self.id_mr:
                 get_logger().warning("Cannot remove reaction: merge request ID is not set.")
                 return False
-            
+
             mr = self.gl.projects.get(self.id_project).mergerequests.get(self.id_mr)
             comment = mr.notes.get(issue_comment_id)
 
             if not comment:
                 get_logger().warning(f"Comment with ID {issue_comment_id} not found in merge request {self.id_mr}.")
                 return False
-            
+
             reactions = comment.awardemojis.list()
             for reaction in reactions:
                 if reaction.name == reaction_id:
                     reaction.delete()
                     return True
-            
+
             get_logger().warning(f"Reaction '{reaction_id}' not found in comment {issue_comment_id}.")
             return False
         except Exception as e:

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -1,35 +1,36 @@
-import pytest
 from unittest.mock import MagicMock, patch
 
-from pr_agent.git_providers.gitlab_provider import GitLabProvider
+import pytest
 from gitlab import Gitlab
-from gitlab.v4.objects import Project, ProjectFile
 from gitlab.exceptions import GitlabGetError
+from gitlab.v4.objects import Project, ProjectFile
+
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
 
 
 class TestGitLabProvider:
     """Test suite for GitLab provider functionality."""
-    
+
     @pytest.fixture
     def mock_gitlab_client(self):
         client = MagicMock()
         return client
-    
+
     @pytest.fixture
     def mock_project(self):
         project = MagicMock()
         return project
-    
+
     @pytest.fixture
     def gitlab_provider(self, mock_gitlab_client, mock_project):
         with patch('pr_agent.git_providers.gitlab_provider.gitlab.Gitlab', return_value=mock_gitlab_client), \
              patch('pr_agent.git_providers.gitlab_provider.get_settings') as mock_settings:
-            
+
             mock_settings.return_value.get.side_effect = lambda key, default=None: {
                 "GITLAB.URL": "https://gitlab.com",
                 "GITLAB.PERSONAL_ACCESS_TOKEN": "fake_token"
             }.get(key, default)
-            
+
             mock_gitlab_client.projects.get.return_value = mock_project
             provider = GitLabProvider("https://gitlab.com/test/repo/-/merge_requests/1")
             provider.gl = mock_gitlab_client
@@ -40,9 +41,9 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = "# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.return_value = mock_file
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == "# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "main")
         mock_file.decode.assert_called_once()
@@ -51,39 +52,39 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = b"# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.return_value = mock_file
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == "# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "main")
 
     def test_get_pr_file_content_file_not_found(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = GitlabGetError("404 Not Found")
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == ""
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "main")
 
     def test_get_pr_file_content_other_exception(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = Exception("Network error")
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == ""
 
     def test_create_or_update_pr_file_create_new(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = GitlabGetError("404 Not Found")
         mock_file = MagicMock()
         mock_project.files.create.return_value = mock_file
-        
+
         new_content = "# Changelog\n\n## v1.1.0\n- New feature"
         commit_message = "Add CHANGELOG.md"
-        
+
         gitlab_provider.create_or_update_pr_file(
             "CHANGELOG.md", "feature-branch", new_content, commit_message
         )
-        
+
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "feature-branch")
         mock_project.files.create.assert_called_once_with({
             'file_path': 'CHANGELOG.md',
@@ -96,21 +97,21 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = "# Old changelog content"
         mock_project.files.get.return_value = mock_file
-        
+
         new_content = "# New changelog content"
         commit_message = "Update CHANGELOG.md"
-        
+
         gitlab_provider.create_or_update_pr_file(
             "CHANGELOG.md", "feature-branch", new_content, commit_message
         )
-        
+
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "feature-branch")
         mock_file.content = new_content
         mock_file.save.assert_called_once_with(branch="feature-branch", commit_message=commit_message)
 
     def test_create_or_update_pr_file_update_exception(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = Exception("Network error")
-        
+
         with pytest.raises(Exception):
             gitlab_provider.create_or_update_pr_file(
                 "CHANGELOG.md", "feature-branch", "content", "message"
@@ -122,10 +123,10 @@ class TestGitLabProvider:
 
     def test_method_signature_compatibility(self, gitlab_provider):
         import inspect
-        
+
         sig = inspect.signature(gitlab_provider.create_or_update_pr_file)
         params = list(sig.parameters.keys())
-        
+
         expected_params = ['file_path', 'branch', 'contents', 'message']
         assert params == expected_params
 
@@ -141,7 +142,40 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = content
         mock_project.files.get.return_value = mock_file
-        
+
         result = gitlab_provider.get_pr_file_content("test.md", "main")
-        
-        assert result == expected 
+
+        assert result == expected
+
+    @pytest.fixture
+    def gitlab_provider_submodule(self, mock_gitlab_client, mock_project):
+        with patch('pr_agent.git_providers.gitlab_provider.gitlab.Gitlab', return_value=mock_gitlab_client), \
+             patch('pr_agent.git_providers.gitlab_provider.get_settings') as mock_settings:
+
+            mock_settings.return_value.get.side_effect = lambda key, default=None: {
+                "GITLAB.URL": "https://gitlab.com",
+                "GITLAB.PERSONAL_ACCESS_TOKEN": "fake_token"
+            }.get(key, default)
+
+            mock_gitlab_client.url = "https://gitlab.com"
+            mock_project.path_with_namespace = "group/main"
+            mock_project.mergerequests.get.return_value = MagicMock()
+            mock_gitlab_client.projects.get.return_value = mock_project
+
+            provider = GitLabProvider("https://gitlab.com/group/main/-/merge_requests/1")
+            provider.gl = mock_gitlab_client
+            provider.id_project = "group/main"
+            return provider
+
+    def test_url_to_project_path_absolute(self, gitlab_provider_submodule):
+        url = "https://gitlab.com/group/sub/repo.git"
+        assert gitlab_provider_submodule._url_to_project_path(url) == "group/sub/repo"
+
+    def test_url_to_project_path_relative(self, gitlab_provider_submodule):
+        url = "../sub/repo.git"
+        assert gitlab_provider_submodule._url_to_project_path(url) == "group/sub/repo"
+
+    def test_url_to_project_path_host_mismatch(self, gitlab_provider_submodule):
+        url = "https://example.com/group/repo.git"
+        with pytest.raises(ValueError):
+            gitlab_provider_submodule._url_to_project_path(url)


### PR DESCRIPTION
## Summary
- validate submodule URLs against GitLab host and support relative `../` paths
- skip submodules from other hosts
- add unit tests for URL resolution scenarios

## Testing
- `pre-commit run --files pr_agent/git_providers/gitlab_provider.py tests/unittest/test_gitlab_provider.py`
- `PYTHONPATH=. pytest tests/unittest/test_gitlab_provider.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae18011b048330bb67d2df9cc09af0