### PR TITLE
Handle GitLab MR changes API failures

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1,13 +1,14 @@
 import difflib
 import hashlib
 import re
-from typing import Optional, Tuple, Any, Union
-from urllib.parse import urlparse, parse_qs
 import urllib.parse
+from typing import Any, Optional, Tuple, Union
+from urllib.parse import parse_qs, urlparse
 
 import gitlab
 import requests
-from gitlab import GitlabGetError, GitlabAuthenticationError, GitlabCreateError, GitlabUpdateError
+from gitlab import (GitlabAuthenticationError, GitlabCreateError,
+                    GitlabGetError, GitlabUpdateError)
 
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
@@ -39,12 +40,12 @@ class GitLabProvider(GitProvider):
             raise ValueError("GitLab personal access token is not set in the config file")
         # Authentication method selection via configuration
         auth_method = get_settings().get("GITLAB.AUTH_TYPE", "oauth_token")
-        
+
         # Basic validation of authentication type
         if auth_method not in ["oauth_token", "private_token"]:
             raise ValueError(f"Unsupported GITLAB.AUTH_TYPE: '{auth_method}'. "
                            f"Must be 'oauth_token' or 'private_token'.")
-        
+
         # Create GitLab instance based on authentication method
         try:
             if auth_method == "oauth_token":
@@ -341,11 +342,11 @@ class GitLabProvider(GitProvider):
         """Create or update a file in the GitLab repository."""
         try:
             project = self.gl.projects.get(self.id_project)
-            
+
             if not message:
                 action = "Update" if contents else "Create"
                 message = f"{action} {file_path}"
-            
+
             try:
                 existing_file = project.files.get(file_path, branch)
                 existing_file.content = contents
@@ -613,7 +614,20 @@ class GitLabProvider(GitProvider):
                     get_logger().exception(f"Failed to create comment in MR {self.id_mr}")
 
     def get_relevant_diff(self, relevant_file: str, relevant_line_in_file: str) -> Optional[dict]:
-        _changes = self.mr.changes()  # dict
+        try:
+            _changes = self.mr.changes()
+        except Exception as e:
+            get_logger().exception(
+                f"Failed to retrieve changes for merge request {self.id_mr}: {e}"
+            )
+            return None
+
+        if not isinstance(_changes, dict):
+            get_logger().error(
+                f"Unexpected changes response for merge request {self.id_mr}: {type(_changes)}"
+            )
+            return None
+
         _changes['changes'] = self._expand_submodule_changes(_changes.get('changes', []))
         changes = _changes
         if not changes:
@@ -784,14 +798,14 @@ class GitLabProvider(GitProvider):
             if not self.id_mr:
                 get_logger().warning("Cannot add eyes reaction: merge request ID is not set.")
                 return None
-            
+
             mr = self.gl.projects.get(self.id_project).mergerequests.get(self.id_mr)
             comment = mr.notes.get(issue_comment_id)
-            
+
             if not comment:
                 get_logger().warning(f"Comment with ID {issue_comment_id} not found in merge request {self.id_mr}.")
                 return None
-            
+
             award_emoji = comment.awardemojis.create({
                 'name': 'eyes'
             })
@@ -805,20 +819,20 @@ class GitLabProvider(GitProvider):
             if not self.id_mr:
                 get_logger().warning("Cannot remove reaction: merge request ID is not set.")
                 return False
-            
+
             mr = self.gl.projects.get(self.id_project).mergerequests.get(self.id_mr)
             comment = mr.notes.get(issue_comment_id)
 
             if not comment:
                 get_logger().warning(f"Comment with ID {issue_comment_id} not found in merge request {self.id_mr}.")
                 return False
-            
+
             reactions = comment.awardemojis.list()
             for reaction in reactions:
                 if reaction.name == reaction_id:
                     reaction.delete()
                     return True
-            
+
             get_logger().warning(f"Reaction '{reaction_id}' not found in comment {issue_comment_id}.")
             return False
         except Exception as e:

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -1,35 +1,36 @@
-import pytest
 from unittest.mock import MagicMock, patch
 
-from pr_agent.git_providers.gitlab_provider import GitLabProvider
+import pytest
 from gitlab import Gitlab
-from gitlab.v4.objects import Project, ProjectFile
 from gitlab.exceptions import GitlabGetError
+from gitlab.v4.objects import Project, ProjectFile
+
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
 
 
 class TestGitLabProvider:
     """Test suite for GitLab provider functionality."""
-    
+
     @pytest.fixture
     def mock_gitlab_client(self):
         client = MagicMock()
         return client
-    
+
     @pytest.fixture
     def mock_project(self):
         project = MagicMock()
         return project
-    
+
     @pytest.fixture
     def gitlab_provider(self, mock_gitlab_client, mock_project):
         with patch('pr_agent.git_providers.gitlab_provider.gitlab.Gitlab', return_value=mock_gitlab_client), \
              patch('pr_agent.git_providers.gitlab_provider.get_settings') as mock_settings:
-            
+
             mock_settings.return_value.get.side_effect = lambda key, default=None: {
                 "GITLAB.URL": "https://gitlab.com",
                 "GITLAB.PERSONAL_ACCESS_TOKEN": "fake_token"
             }.get(key, default)
-            
+
             mock_gitlab_client.projects.get.return_value = mock_project
             provider = GitLabProvider("https://gitlab.com/test/repo/-/merge_requests/1")
             provider.gl = mock_gitlab_client
@@ -40,9 +41,9 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = "# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.return_value = mock_file
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == "# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "main")
         mock_file.decode.assert_called_once()
@@ -51,39 +52,39 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = b"# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.return_value = mock_file
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == "# Changelog\n\n## v1.0.0\n- Initial release"
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "main")
 
     def test_get_pr_file_content_file_not_found(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = GitlabGetError("404 Not Found")
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == ""
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "main")
 
     def test_get_pr_file_content_other_exception(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = Exception("Network error")
-        
+
         content = gitlab_provider.get_pr_file_content("CHANGELOG.md", "main")
-        
+
         assert content == ""
 
     def test_create_or_update_pr_file_create_new(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = GitlabGetError("404 Not Found")
         mock_file = MagicMock()
         mock_project.files.create.return_value = mock_file
-        
+
         new_content = "# Changelog\n\n## v1.1.0\n- New feature"
         commit_message = "Add CHANGELOG.md"
-        
+
         gitlab_provider.create_or_update_pr_file(
             "CHANGELOG.md", "feature-branch", new_content, commit_message
         )
-        
+
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "feature-branch")
         mock_project.files.create.assert_called_once_with({
             'file_path': 'CHANGELOG.md',
@@ -96,21 +97,21 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = "# Old changelog content"
         mock_project.files.get.return_value = mock_file
-        
+
         new_content = "# New changelog content"
         commit_message = "Update CHANGELOG.md"
-        
+
         gitlab_provider.create_or_update_pr_file(
             "CHANGELOG.md", "feature-branch", new_content, commit_message
         )
-        
+
         mock_project.files.get.assert_called_once_with("CHANGELOG.md", "feature-branch")
         mock_file.content = new_content
         mock_file.save.assert_called_once_with(branch="feature-branch", commit_message=commit_message)
 
     def test_create_or_update_pr_file_update_exception(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = Exception("Network error")
-        
+
         with pytest.raises(Exception):
             gitlab_provider.create_or_update_pr_file(
                 "CHANGELOG.md", "feature-branch", "content", "message"
@@ -122,10 +123,10 @@ class TestGitLabProvider:
 
     def test_method_signature_compatibility(self, gitlab_provider):
         import inspect
-        
+
         sig = inspect.signature(gitlab_provider.create_or_update_pr_file)
         params = list(sig.parameters.keys())
-        
+
         expected_params = ['file_path', 'branch', 'contents', 'message']
         assert params == expected_params
 
@@ -141,7 +142,24 @@ class TestGitLabProvider:
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = content
         mock_project.files.get.return_value = mock_file
-        
+
         result = gitlab_provider.get_pr_file_content("test.md", "main")
-        
-        assert result == expected 
+
+        assert result == expected
+
+    def test_get_relevant_diff_changes_exception(self, gitlab_provider):
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.mr.changes.side_effect = Exception("API failure")
+
+        result = gitlab_provider.get_relevant_diff("file.py", "line")
+
+        assert result is None
+
+
+    def test_get_relevant_diff_changes_not_dict(self, gitlab_provider):
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.mr.changes.return_value = []
+
+        result = gitlab_provider.get_relevant_diff("file.py", "line")
+
+        assert result is None


### PR DESCRIPTION
## Summary
- handle errors when retrieving GitLab merge request changes
- test GitLab provider behavior on changes API failures

## Testing
- `pre-commit run --files pr_agent/git_providers/gitlab_provider.py tests/unittest/test_gitlab_provider.py`
- `PYTHONPATH=. pytest tests/unittest/test_gitlab_provider.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae18082cd48330b7a3cf3f88cd4e73