### PR TITLE
docs: document GitLab submodule diff option

### DIFF
--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -275,6 +275,7 @@ push_commands = [
 
 [gitlab]
 url = "https://gitlab.com"
+expand_submodule_diffs = false
 pr_commands = [
     "/describe --pr_description.final_update_message=false",
     "/review",


### PR DESCRIPTION
## Summary
- document `expand_submodule_diffs` GitLab option in config

## Testing
- `pre-commit run --files pr_agent/settings/configuration.toml`
- `pytest` *(fails: 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fbb8e3a4833098bedebb5442fd3e